### PR TITLE
Stop vectors from being converted to another sequence type

### DIFF
--- a/src/scim_patch/core.clj
+++ b/src/scim_patch/core.clj
@@ -62,7 +62,7 @@
   (if (:multi-valued schema)
     (if (and (sequential? new-val)
           (or (nil? old-val) (sequential? old-val)))
-      (concat old-val new-val)
+      (vec (concat old-val new-val))
       (throw (ex-info "Invalid value for multivalued attribute"
                {:status   400
                 :scimType :invalidValue})))
@@ -102,7 +102,7 @@
                        {:status   400
                         :scimType :invalidFilter})))
             (update res (keyword attr)
-              #(doall (map (filter-and-add sch value value-filter subattr) %))))]
+              #(doall (mapv (filter-and-add sch value value-filter subattr) %))))]
 
     (handle-operation schema resource opr add-attr-path add-value-path)))
 

--- a/test/scim_patch/core_test.clj
+++ b/test/scim_patch/core_test.clj
@@ -129,7 +129,6 @@
              :path  "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:emails"
              :value ["test2@example.com"]})))))
 
-
 (deftest op-add-attr-path-level-3
   (testing "add operation, no filter, single valued, level 3"
     (is (= {:urn:ietf:params:scim:schemas:extension:enterprise:2.0:User {:manager {:displayName "Eddie Brock"}}}
@@ -163,7 +162,7 @@
                        :value {:phoneNumbers [{:value "555-555-4444" :type  "mobile"}]}})))))
 
 (deftest op-add-no-path-nested
-  (testing "add operation, no path"
+  (testing "add operation, no path, nested"
     (is (= {:name {:honorificPrefix ["Mr." "Dr."]}}
            (sut/patch schema
                       {:name {:honorificPrefix ["Mr."]}}


### PR DESCRIPTION
In some cases, vectors were being converted to another sequence type (lazy sequences) in the patch output.  This PR stops that from happening.  Note that this was not detected by the tests, because in Clojure we have:

```clojure
(= [1 2 3] (lazy-seq [1 2 3]))
=> true
```